### PR TITLE
Firefox 135

### DIFF
--- a/chrome/context_menu.css
+++ b/chrome/context_menu.css
@@ -4,12 +4,14 @@
 main menu fix */
 .PanelUI-subView{max-height:unset!important;}
 
-/* truncate "Copy Link Without Tracking" to "Copy Link" */
-#context-stripOnShareLink label[crop]:before{max-width: 9ch;text-overflow:clip!important;}
-#strip-on-share label[crop]:before{max-width: 5ch;text-overflow:clip!important;}
-/* hide disabled "Copy Link Without Tracking" items */
+/* truncate "Copy Clean Link" */
+#strip-on-share label[crop],#context-stripOnShareLink label[crop]{color:transparent;position:relative}
+#strip-on-share label[crop]::after{color:#fff;content:'Copy';position:absolute}
+#context-stripOnShareLink label[crop]::after{color:#fff;content:'Copy Link';position:absolute}
+
+/* hide disabled "Copy Clean Link" items */
 #context-stripOnShareLink[disabled="true"],#strip-on-share[disabled="true"],
-/* hide "Copy Link" when "Copy Link Without Tracking" is enabled */
+/* hide "Copy Link" when "Copy Clean Link" is enabled */
 #context-copylink:has( + #context-stripOnShareLink:not([disabled="true"]) ),
 menuitem[label="Copy"]:has( + #strip-on-share:not([disabled="true"]) ){display:none!important}
 

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -19,6 +19,8 @@
 .tab-throbber[busy]:not([progress]){filter:grayscale(100%)}
 }
 
+@media not (-moz-bool-pref: "sidebar.verticalTabs") {
+
 /* proper tabs */
 :root{--tab-block-margin:0!important}
 .tabbrowser-tab{padding-inline:0!important}
@@ -33,3 +35,5 @@
 /* tab dividers/separators */
 .tabbrowser-tab:not([selected],[multiselected]) + .tabbrowser-tab:not([selected],[multiselected]) .tab-background:after{border-left:1px solid #444445;height:100%;position:absolute}
 .tab-background:after{content:"";left:0}
+
+}


### PR DESCRIPTION
* Truncate `Copy Clean Link` to `Copy Link`
* Tabs are only changed if `sidebar.verticalTabs`  is set to `false`